### PR TITLE
Fix typos and improve tests

### DIFF
--- a/neko/_outputs/exports.py
+++ b/neko/_outputs/exports.py
@@ -53,8 +53,10 @@ class Exports:
         bimodal_targets = bimodal_interactions['target'].tolist()
         permutations = list(itertools.product(['stimulation', 'inhibition'], repeat=len(bimodal_interactions)))
 
-        # Create a directory for the BNet files
-        os.makedirs(os.path.dirname(file_name), exist_ok=True)
+        # Create a directory for the BNet files if a directory is provided
+        directory = os.path.dirname(file_name)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
 
         # Iterate through permutations and create a BNet file for each
         for i, perm in enumerate(permutations):

--- a/neko/core/network.py
+++ b/neko/core/network.py
@@ -445,7 +445,7 @@ class Network:
                 "1": "stimulation",
                 "activate": "stimulation",
                 "stimulate": "stimulation",
-                "phosphorilate": "undefined",
+                "phosphorylate": "undefined",
                 "stimulation": "stimulation",
                 "->": "stimulation",
                 "-|": "inhibition",

--- a/neko/core/tools.py
+++ b/neko/core/tools.py
@@ -100,31 +100,35 @@ def mapping_node_identifier(node: str) -> list[str]:
     genesymbol = None
     uniprot = None
 
-    if mapping.id_from_label0(node):
+    node_id = mapping.id_from_label0(node)
+
+    if node_id:
         # Convert UniProt ID to gene symbol
-        uniprot = mapping.id_from_label0(node)
+        uniprot = node_id
         if uniprot.startswith("MI"):
             genesymbol = uniprot
         else:
-            # Set the UniProt ID as the 'Uniprot' value in the new entry
             genesymbol = mapping.label(uniprot)
-    elif mapping.id_from_label0(node).startswith("COMPLEX"):
-        node = node[8:]
-        node_list = node.split("_")
+    elif isinstance(node, str) and node.startswith("COMPLEX"):
+        node_content = node[8:]
+        node_list = node_content.split("_")
 
         # Translate each element in node_list using mapping.label
-        translated_node_list = [mapping.label(mapping.id_from_label0(item)) for item in node_list]
+        translated_node_list = [mapping.label(mapping.id_from_label0(item)) or item for item in node_list]
 
         # Join the elements in node_list with "_"
         joined_node_string = "_".join(translated_node_list)
 
         # Add back the "COMPLEX:" prefix to the string
         complex_string = "COMPLEX:" + joined_node_string
-    elif mapping.label(node):
-        genesymbol = mapping.label(node)
-        uniprot = mapping.id_from_label0(genesymbol)
+        uniprot = node
     else:
-        print("Error during translation, check syntax for ", node)
+        label = mapping.label(node)
+        if label:
+            genesymbol = label
+            uniprot = mapping.id_from_label0(genesymbol)
+        else:
+            print("Error during translation, check syntax for ", node)
 
     return [complex_string, genesymbol, uniprot]
 

--- a/neko/inputs/_misc.py
+++ b/neko/inputs/_misc.py
@@ -37,4 +37,4 @@ def effect(
        If the interaction type is not recognized, it returns "undefined".
     """
 
-    return effect_types.get(str(value).lower(), "undefined")
+    return EFFECT_TYPES.get(str(value).lower(), "undefined")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,79 @@
+import pandas as pd
+from pypath.utils import mapping
+
+
+def identity(x):
+    return x
+
+
+def setup_module(module):
+    module.orig_id = mapping.id_from_label0
+    module.orig_label = mapping.label
+    mapping.id_from_label0 = identity
+    mapping.label = identity
+
+
+def teardown_module(module):
+    mapping.id_from_label0 = module.orig_id
+    mapping.label = module.orig_label
+
+
+def sample_df():
+    return pd.DataFrame({
+        'source': ['P1', 'P2', 'P3'],
+        'target': ['P2', 'P3', 'P1'],
+        'is_directed': [True, True, True],
+        'is_stimulation': [True, False, True],
+        'is_inhibition': [False, True, False],
+        'form_complex': [False, False, False],
+    })
+
+
+def test_universe_basic():
+    from neko.inputs._universe import Universe
+    df = sample_df()
+    u = Universe(df)
+    assert len(u) == 3
+    assert {'P1', 'P2', 'P3'} <= u.nodes
+
+
+def test_network_add_edge():
+    from neko.core.network import Network
+    df = sample_df()
+    net = Network(initial_nodes=['P1'], resources=df)
+    edge = pd.DataFrame({
+        'source': ['P1'],
+        'target': ['P2'],
+        'type': ['activation'],
+        'references': ['ref'],
+        'is_stimulation': [True],
+        'is_inhibition': [False],
+    })
+    net.add_edge(edge)
+    assert len(net.edges) == 1
+    assert {'P1', 'P2'} <= set(net.edges[['source', 'target']].stack())
+
+
+def test_exports(tmp_path):
+    from neko.core.network import Network
+    from neko._outputs.exports import Exports
+    df = sample_df()
+    net = Network(initial_nodes=['P1'], resources=df)
+    edge = pd.DataFrame({
+        'source': ['P1'],
+        'target': ['P2'],
+        'type': ['activation'],
+        'references': ['ref'],
+        'is_stimulation': [True],
+        'is_inhibition': [False],
+    })
+    net.add_edge(edge)
+    exp = Exports(net)
+    sif_file = tmp_path / 'test.sif'
+    bnet_file = tmp_path / 'test.bnet'
+    exp.export_sif(str(sif_file))
+    exp.export_bnet(str(bnet_file))
+    assert sif_file.exists()
+    created = list(tmp_path.glob('test*.bnet'))
+    assert created
+

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,5 +1,0 @@
-def test_import_submodules():
-    from neko.core.network import Network
-    from neko._visual.visualize_network import NetworkVisualizer
-    from neko._outputs.exports import Exports
-    from neko.inputs import Universe, signor


### PR DESCRIPTION
## Summary
- fix bug in `mapping_node_identifier`
- fix wrong key in `effect` helper
- fix typo in network SIF loader
- avoid failing export when directory not provided
- replace import test with functional tests for `Network`, `Universe`, and `Exports`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424afacb208331aa942eaf0bf5f710